### PR TITLE
BRS-33 Enable public to be serve from /dayuse path

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -185,7 +185,7 @@ jobs:
 
   s3:
     name: Upload to S3 Dev
-    needs: [build, terragrunt]
+    needs: [build]
     runs-on: ubuntu-20.04
     environment: dev
     strategy:
@@ -236,4 +236,4 @@ jobs:
           s3_bucket: "${{ env.S3_BUCKET }}-${{ env.TARGET_ENV }}"
           dir_name: ${{ github.sha }}
         run: |
-          aws s3 sync dist/parks-reso-public s3://$s3_bucket/$dir_name/
+          aws s3 sync dist/parks-reso-public s3://$s3_bucket/$dir_name/dayuse

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -152,4 +152,4 @@ jobs:
           s3_bucket: "${{ env.S3_BUCKET }}-${{ env.TARGET_ENV }}"
           dir_name: ${{ github.event.inputs.releaseTag }}
         run: |
-          aws s3 sync dist/parks-reso-public s3://$s3_bucket/$dir_name/
+          aws s3 sync dist/parks-reso-public s3://$s3_bucket/$dir_name/dayuse

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -149,4 +149,4 @@ jobs:
           s3_bucket: "${{ env.S3_BUCKET }}-${{ env.TARGET_ENV }}"
           dir_name: ${{ github.event.inputs.releaseTag }}
         run: |
-          aws s3 sync dist/parks-reso-public s3://$s3_bucket/$dir_name/
+          aws s3 sync dist/parks-reso-public s3://$s3_bucket/$dir_name/dayuse

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build",
+    "start": "ng serve --base-href /dayuse/ --deploy-url /dayuse/",
+    "build": "ng build --base-href /dayuse/ --deploy-url /dayuse/",
     "test": "ng test --watch=false",
     "test-ci": "ng test --watch=false --browsers=ChromeHeadless",
     "lint": "ng lint",

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -5,7 +5,7 @@
             title="BC Parks Reservations"
             tabIndex="1"
             href="https://bcparks.ca/">
-            <img src="/assets/images/bcgov-header-horiz-LG.png"
+            <img src="assets/images/bcgov-header-horiz-LG.png"
                 class="d-inline-block bc-gov-logo"
                 alt="">
             <img src="https://bcparks.ca/_shared/images/logos/logo-bcparks-text.png"
@@ -20,7 +20,7 @@
             title="BC Parks Reservations"
             tabIndex="1"
             href="https://bcparks.ca/">
-            <img src="/assets/images/bcgov-header-horiz-LG.png"
+            <img src="assets/images/bcgov-header-horiz-LG.png"
                 alt=""
                 width="115"
                 height="32"

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -26,7 +26,7 @@ export class ConfigService {
       try {
         // Attempt to get application via this.httpClient. This uses the url of the application that you are running it from
         // This will not work for local because it will try and get localhost:4200/api instead of 3000/api...
-        this.configuration = await this.httpClient.get(`api/config`).toPromise();
+        this.configuration = await this.httpClient.get(`/api/config`).toPromise();
       } catch (e) {
         // If all else fails, we'll just use the variables found in env.js
         console.error('Error getting local configuration:', e);

--- a/src/assets/base/material-icons.scss
+++ b/src/assets/base/material-icons.scss
@@ -5,12 +5,12 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(/assets/fonts/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: url(~/assets/fonts/MaterialIcons-Regular.eot); /* For IE6-8 */
   src: local('Material Icons'),
        local('MaterialIcons-Regular'),
-       url(/assets/fonts/MaterialIcons-Regular.woff2) format('woff2'),
-       url(/assets/fonts/MaterialIcons-Regular.woff) format('woff'),
-       url(/assets/fonts/MaterialIcons-Regular.ttf) format('truetype');
+       url(~/assets/fonts/MaterialIcons-Regular.woff2) format('woff2'),
+       url(~/assets/fonts/MaterialIcons-Regular.woff) format('woff'),
+       url(~/assets/fonts/MaterialIcons-Regular.ttf) format('truetype');
 }
 
 .material-icons {

--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,7 @@
     content="width=device-width, initial-scale=1">
   <link rel="icon"
     type="image/x-icon"
-    href="/assets/images/favicon_bcid.ico">
+    href="assets/images/favicon_bcid.ico">
   <script src="env.js"></script>
 </head>
 

--- a/terraform/prod/terragrunt.hcl
+++ b/terraform/prod/terragrunt.hcl
@@ -37,6 +37,6 @@ auth_user = "${local.auth_user}"
 auth_pass = "${local.auth_pass}"
 enable_vanity_domain = true
 vanity_domain_certs_arn = "${local.ssl_cert_arn}"
-vanity_domain = ["parkingpass.bcparks.ca"]
+vanity_domain = ["parkingpass.bcparks.ca", "reserve.bcparks.ca"]
 EOF
 }


### PR DESCRIPTION
### Jira Ticket:
BRS-33

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-33

### Description:
- Updated Angular project to be served from `/dayuse` subpath
- Builds are copied to `/dayuse` subfolder to allow Cloudfront to redirect correctly

This is not the prettiest solution since all default traffic will go to `/dayuse` subpath.   