### PR TITLE
BRS-167: hide daypass times that are not offered

### DIFF
--- a/src/app/registration/facility-select/facility-select.component.html
+++ b/src/app/registration/facility-select/facility-select.component.html
@@ -40,8 +40,11 @@
     <fieldset class="form-group"
         [disabled]="isDisabled('time')">
         <label for="visitDate">Booking Time</label>
+        <div *ngIf="!timeConfig.AM.offered && !timeConfig.PM.offered && !timeConfig.DAY.offered">
+            <p class="text-muted">Please select a date to see available passes for that day.</p>
+        </div>
         <div class="row">
-            <div class="col-lg-4">
+            <div class="col-lg-4" *ngIf="timeConfig.AM.offered">
                 <label>
                     <input type="radio"
                         name="visitTime"
@@ -75,7 +78,7 @@
                     </div>
                 </label>
             </div>
-            <div class="col-lg-4">
+            <div class="col-lg-4" *ngIf="timeConfig.PM.offered">
                 <label>
                     <input type="radio"
                         name="visitTime"
@@ -109,7 +112,7 @@
                     </div>
                 </label>
             </div>
-            <div class="col-lg-4">
+            <div class="col-lg-4" *ngIf="timeConfig.DAY.offered">
                 <label>
                     <input type="radio"
                         name="visitTime"

--- a/src/app/registration/facility-select/facility-select.component.ts
+++ b/src/app/registration/facility-select/facility-select.component.ts
@@ -28,15 +28,18 @@ export class FacilitySelectComponent implements OnInit {
     AM: {
       selected: false,
       disabled: true,
+      offered: false,
       text: ''
     },
     PM: {
       selected: false,
+      offered: false,
       disabled: true,
       text: ''
     },
     DAY: {
       selected: false,
+      offered: false,
       disabled: true,
       text: ''
     }
@@ -93,8 +96,17 @@ export class FacilitySelectComponent implements OnInit {
     if (this.myForm.get('passType').value && this.myForm.get('passType').value.bookingTimes) {
       const facility = this.myForm.get('passType').value;
       const times = this.myForm.get('passType').value.bookingTimes;
+      if (times.AM) {
+        this.timeConfig.AM.offered = true;
+      }
+      if (times.PM) {
+        this.timeConfig.PM.offered = true;
+      }
+      if (times.DAY) {
+        this.timeConfig.DAY.offered = true;
+      }
       this.selectedDate = this.getBookingDateString();
-      this.timeConfig['AM'].text = this.timeConfig['PM'].text = this.timeConfig['DAY'].text = 'Unavailable';
+      this.timeConfig['AM'].text = this.timeConfig['PM'].text = this.timeConfig['DAY'].text = 'Unoffered';
       for (let key in times) {
         if (!facility.reservations[this.selectedDate]) {
           // This happens if there are no existing passes for the day.
@@ -270,16 +282,19 @@ export class FacilitySelectComponent implements OnInit {
     this.timeConfig = {
       AM: {
         selected: false,
+        offered: false,
         disabled: true,
         text: '-'
       },
       PM: {
         selected: false,
+        offered: false,
         disabled: true,
         text: '-'
       },
       DAY: {
         selected: false,
+        offered: false,
         disabled: true,
         text: '-'
       }


### PR DESCRIPTION
### Jira Ticket:
BRS-167

### Jira Ticket URL:
https://bcmines.atlassian.net/browse/BRS-167

### Description:
This change prevents timeslots from displaying if the facility does not offer them (`AM`, `PM`, `DAY`). The field 'offered' is added to the 'timeConfig' object and checks whether that particular timeslot is offered. Timeslots that are offered but unavailable because they are full are still shown as disabled. 