### PR TITLE
BRS-219: upload to s3 before updating cloudfront distribution

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -29,12 +29,12 @@ jobs:
       - name: Install dependencies
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
-      
+
       - run: yarn lint
       - name: Cancelling workflow due to error
         if: ${{ failure() }}
         uses: andymckay/cancel-action@0.2
-  
+
   test:
     name: Test
     runs-on: ubuntu-20.04
@@ -79,7 +79,7 @@ jobs:
 
       - name: Setting configEndpoint to true
         run: sed 's@localConfigEndpoint@'true'@g' src/env.js.template > src/env.js
-      
+
       - run: yarn build
 
       - name: Configure AWS credentials
@@ -93,102 +93,18 @@ jobs:
           role-session-name: parks-reso-public-sandbox-gh-action
           role-skip-session-tagging: true
 
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
-          ssm_parameter: "/parks-reso-sandbox/s3-bucket-public-artifacts"
-          env_variable_name: "S3_BUCKET_ARTIFACTS"
+          ssm_parameter: '/parks-reso-sandbox/s3-bucket-public-artifacts'
+          env_variable_name: 'S3_BUCKET_ARTIFACTS'
 
       - name: Save artifact to S3
         env:
-          s3_bucket: "${{ env.S3_BUCKET_ARTIFACTS }}"
+          s3_bucket: '${{ env.S3_BUCKET_ARTIFACTS }}'
           dir_name: ${{ github.sha }}
         run: |
           aws s3 sync dist/parks-reso-public s3://$s3_bucket/$dir_name/
-      
-      - name: Cancelling workflow due to error
-        if: ${{ failure() }}
-        uses: andymckay/cancel-action@0.2
 
-  terragrunt:
-    name: Run Terragrunt
-    runs-on: ubuntu-20.04
-    environment: dev
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
-          role-session-name: parks-reso-public-dev-gh-action
-          role-skip-session-tagging: true
-
-      # Public variables
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
-        with:
-          ssm_parameter: "/parks-reso-public/s3-bucket"
-          env_variable_name: "S3_BUCKET"
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
-        with:
-          ssm_parameter: "/parks-reso-public/origin-id"
-          env_variable_name: "ORIGIN_ID"
-
-      # API variables
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
-        with:
-          ssm_parameter: /parks-reso-api/origin-domain
-          env_variable_name: "API_GATEWAY_ORIGIN_DOMAIN"
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
-        with:
-          ssm_parameter: /parks-reso-api/origin-id
-          env_variable_name: "API_GATEWAY_ORIGIN_ID"
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
-        with:
-          ssm_parameter: /parks-reso-api/gateway-path-pattern
-          env_variable_name: "API_GATEWAY_PATH_PATTERN"
-
-      # Shared variables
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
-        with:
-          ssm_parameter: "/parks-reso-shared/s3-bucket-assets"
-          env_variable_name: "S3_BUCKET_ASSETS"
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
-        with:
-          ssm_parameter: "/parks-reso-shared/origin-id-assets"
-          env_variable_name: "ORIGIN_ID_ASSETS"
-
-      - name: Setup Terrafrom
-        uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: ${{ env.TF_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
-
-      - name: Setup terragrunt
-        uses: peter-murray/terragrunt-github-action@v1.0.0
-        with:
-          terragrunt_version: ${{ env.TG_VERSION }}
-
-      - name: Terragrunt Apply
-        working-directory: ${{ env.TG_SRC_PATH }}/${{ env.TFC_WORKSPACE }}
-        env:
-          app_version: ${{ github.sha }}
-          s3_bucket: ${{ env.S3_BUCKET }}
-          s3_bucket_assets: ${{ env.S3_BUCKET_ASSETS }}
-          origin_id: ${{ env.ORIGIN_ID }}
-          api_gateway_origin_domain: ${{ env.API_GATEWAY_ORIGIN_DOMAIN }}
-          api_gateway_origin_id: ${{ env.API_GATEWAY_ORIGIN_ID }}
-          api_gateway_path_pattern: ${{ env.API_GATEWAY_PATH_PATTERN }}
-          origin_id_assets: ${{ env.ORIGIN_ID_ASSETS }}
-        run: terragrunt apply-all --terragrunt-non-interactive
-      
       - name: Cancelling workflow due to error
         if: ${{ failure() }}
         uses: andymckay/cancel-action@0.2
@@ -213,14 +129,14 @@ jobs:
           role-session-name: parks-reso-public-sandbox-gh-action
           role-skip-session-tagging: true
 
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
-          ssm_parameter: "/parks-reso-sandbox/s3-bucket-public-artifacts"
-          env_variable_name: "S3_BUCKET_ARTIFACTS"
+          ssm_parameter: '/parks-reso-sandbox/s3-bucket-public-artifacts'
+          env_variable_name: 'S3_BUCKET_ARTIFACTS'
 
       - name: Copy from s3 sandbox
         env:
-          s3_bucket: "${{ env.S3_BUCKET_ARTIFACTS }}"
+          s3_bucket: '${{ env.S3_BUCKET_ARTIFACTS }}'
           dir_name: ${{ github.sha }}
         run: |
           aws s3 sync s3://$s3_bucket/$dir_name/ dist/parks-reso-public
@@ -236,14 +152,99 @@ jobs:
           role-session-name: parks-reso-public-dev-gh-action
           role-skip-session-tagging: true
 
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
-          ssm_parameter: "/parks-reso-public/s3-bucket"
-          env_variable_name: "S3_BUCKET"
+          ssm_parameter: '/parks-reso-public/s3-bucket'
+          env_variable_name: 'S3_BUCKET'
 
       - name: Deploy to Dev S3
         env:
-          s3_bucket: "${{ env.S3_BUCKET }}-${{ env.TARGET_ENV }}"
+          s3_bucket: '${{ env.S3_BUCKET }}-${{ env.TARGET_ENV }}'
           dir_name: ${{ github.sha }}
         run: |
           aws s3 sync dist/parks-reso-public s3://$s3_bucket/$dir_name/dayuse
+
+  terragrunt:
+    name: Run Terragrunt
+    needs: ['s3']
+    runs-on: ubuntu-20.04
+    environment: dev
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 900
+          role-session-name: parks-reso-public-dev-gh-action
+          role-skip-session-tagging: true
+
+      # Public variables
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
+        with:
+          ssm_parameter: '/parks-reso-public/s3-bucket'
+          env_variable_name: 'S3_BUCKET'
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
+        with:
+          ssm_parameter: '/parks-reso-public/origin-id'
+          env_variable_name: 'ORIGIN_ID'
+
+      # API variables
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
+        with:
+          ssm_parameter: /parks-reso-api/origin-domain
+          env_variable_name: 'API_GATEWAY_ORIGIN_DOMAIN'
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
+        with:
+          ssm_parameter: /parks-reso-api/origin-id
+          env_variable_name: 'API_GATEWAY_ORIGIN_ID'
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
+        with:
+          ssm_parameter: /parks-reso-api/gateway-path-pattern
+          env_variable_name: 'API_GATEWAY_PATH_PATTERN'
+
+      # Shared variables
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
+        with:
+          ssm_parameter: '/parks-reso-shared/s3-bucket-assets'
+          env_variable_name: 'S3_BUCKET_ASSETS'
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
+        with:
+          ssm_parameter: '/parks-reso-shared/origin-id-assets'
+          env_variable_name: 'ORIGIN_ID_ASSETS'
+
+      - name: Setup Terrafrom
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+          cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
+
+      - name: Setup terragrunt
+        uses: peter-murray/terragrunt-github-action@v1.0.0
+        with:
+          terragrunt_version: ${{ env.TG_VERSION }}
+
+      - name: Terragrunt Apply
+        working-directory: ${{ env.TG_SRC_PATH }}/${{ env.TFC_WORKSPACE }}
+        env:
+          app_version: ${{ github.sha }}
+          s3_bucket: ${{ env.S3_BUCKET }}
+          s3_bucket_assets: ${{ env.S3_BUCKET_ASSETS }}
+          origin_id: ${{ env.ORIGIN_ID }}
+          api_gateway_origin_domain: ${{ env.API_GATEWAY_ORIGIN_DOMAIN }}
+          api_gateway_origin_id: ${{ env.API_GATEWAY_ORIGIN_ID }}
+          api_gateway_path_pattern: ${{ env.API_GATEWAY_PATH_PATTERN }}
+          origin_id_assets: ${{ env.ORIGIN_ID_ASSETS }}
+        run: terragrunt apply-all --terragrunt-non-interactive
+
+      - name: Cancelling workflow due to error
+        if: ${{ failure() }}
+        uses: andymckay/cancel-action@0.2

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseTag:
-        description: "Tag of version to be promoted to prod"
+        description: 'Tag of version to be promoted to prod'
         required: true
 
 env:
@@ -15,8 +15,63 @@ env:
   TARGET_ENV: prod
 
 jobs:
+  s3:
+    name: Upload to S3
+    runs-on: ubuntu-20.04
+    environment: prod
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SANDBOX }}
+          role-duration-seconds: 900
+          role-session-name: parks-reso-public-sandbox-gh-action
+          role-skip-session-tagging: true
+
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
+        with:
+          ssm_parameter: '/parks-reso-sandbox/s3-bucket-public-artifacts'
+          env_variable_name: 'S3_BUCKET_ARTIFACTS'
+
+      - name: Copy from s3 sandbox
+        env:
+          s3_bucket: '${{ env.S3_BUCKET_ARTIFACTS }}'
+          dir_name: ${{ github.sha }}
+        run: |
+          aws s3 sync s3://$s3_bucket/$dir_name/ dist/parks-reso-public
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 900
+          role-session-name: parks-reso-public-prod-gh-action
+          role-skip-session-tagging: true
+
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
+        with:
+          ssm_parameter: '/parks-reso-public/s3-bucket'
+          env_variable_name: 'S3_BUCKET'
+
+      - name: Deploy to Prod S3
+        env:
+          s3_bucket: '${{ env.S3_BUCKET }}-${{ env.TARGET_ENV }}'
+          dir_name: ${{ github.event.inputs.releaseTag }}
+        run: |
+          aws s3 sync dist/parks-reso-public s3://$s3_bucket/$dir_name/dayuse
+
   terragrunt:
     name: Run Terragrunt
+    needs: ['s3']
     runs-on: ubuntu-20.04
     environment: prod
     strategy:
@@ -39,38 +94,38 @@ jobs:
           role-skip-session-tagging: true
 
       # Public variables
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
-          ssm_parameter: "/parks-reso-public/s3-bucket"
-          env_variable_name: "S3_BUCKET"
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+          ssm_parameter: '/parks-reso-public/s3-bucket'
+          env_variable_name: 'S3_BUCKET'
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
-          ssm_parameter: "/parks-reso-public/origin-id"
-          env_variable_name: "ORIGIN_ID"
+          ssm_parameter: '/parks-reso-public/origin-id'
+          env_variable_name: 'ORIGIN_ID'
 
       # API variables
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
           ssm_parameter: /parks-reso-api/origin-domain
-          env_variable_name: "API_GATEWAY_ORIGIN_DOMAIN"
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+          env_variable_name: 'API_GATEWAY_ORIGIN_DOMAIN'
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
           ssm_parameter: /parks-reso-api/origin-id
-          env_variable_name: "API_GATEWAY_ORIGIN_ID"
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+          env_variable_name: 'API_GATEWAY_ORIGIN_ID'
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
           ssm_parameter: /parks-reso-api/gateway-path-pattern
-          env_variable_name: "API_GATEWAY_PATH_PATTERN"
+          env_variable_name: 'API_GATEWAY_PATH_PATTERN'
 
       # Shared variables
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
-          ssm_parameter: "/parks-reso-shared/s3-bucket-assets"
-          env_variable_name: "S3_BUCKET_ASSETS"
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+          ssm_parameter: '/parks-reso-shared/s3-bucket-assets'
+          env_variable_name: 'S3_BUCKET_ASSETS'
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
-          ssm_parameter: "/parks-reso-shared/origin-id-assets"
-          env_variable_name: "ORIGIN_ID_ASSETS"
+          ssm_parameter: '/parks-reso-shared/origin-id-assets'
+          env_variable_name: 'ORIGIN_ID_ASSETS'
 
       - name: Setup Terrafrom
         uses: hashicorp/setup-terraform@v1
@@ -98,58 +153,3 @@ jobs:
           auth_pass: ${{ secrets.BASIC_AUTH_PASS }}
           ssl_cert_arn: ${{ secrets.PARKS_SSL_CERT_ARN }}
         run: terragrunt apply-all --terragrunt-non-interactive
-
-  s3:
-    name: Upload to S3
-    needs: terragrunt
-    runs-on: ubuntu-20.04
-    environment: prod
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SANDBOX }}
-          role-duration-seconds: 900
-          role-session-name: parks-reso-public-sandbox-gh-action
-          role-skip-session-tagging: true
-
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
-        with:
-          ssm_parameter: "/parks-reso-sandbox/s3-bucket-public-artifacts"
-          env_variable_name: "S3_BUCKET_ARTIFACTS"
-
-      - name: Copy from s3 sandbox
-        env:
-          s3_bucket: "${{ env.S3_BUCKET_ARTIFACTS }}"
-          dir_name: ${{ github.sha }}
-        run: |
-          aws s3 sync s3://$s3_bucket/$dir_name/ dist/parks-reso-public
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
-          role-session-name: parks-reso-public-prod-gh-action
-          role-skip-session-tagging: true
-
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
-        with:
-          ssm_parameter: "/parks-reso-public/s3-bucket"
-          env_variable_name: "S3_BUCKET"
-
-      - name: Deploy to Prod S3
-        env:
-          s3_bucket: "${{ env.S3_BUCKET }}-${{ env.TARGET_ENV }}"
-          dir_name: ${{ github.event.inputs.releaseTag }}
-        run: |
-          aws s3 sync dist/parks-reso-public s3://$s3_bucket/$dir_name/dayuse

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseTag:
-        description: 'Tag of version to be promoted to test'     
+        description: 'Tag of version to be promoted to test'
         required: true
 
 env:
@@ -15,8 +15,63 @@ env:
   TARGET_ENV: test
 
 jobs:
+  s3:
+    name: Upload to S3
+    runs-on: ubuntu-20.04
+    environment: test
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SANDBOX }}
+          role-duration-seconds: 900
+          role-session-name: parks-reso-public-sandbox-gh-action
+          role-skip-session-tagging: true
+
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
+        with:
+          ssm_parameter: '/parks-reso-sandbox/s3-bucket-public-artifacts'
+          env_variable_name: 'S3_BUCKET_ARTIFACTS'
+
+      - name: Copy from s3 sandbox
+        env:
+          s3_bucket: '${{ env.S3_BUCKET_ARTIFACTS }}'
+          dir_name: ${{ github.sha }}
+        run: |
+          aws s3 sync s3://$s3_bucket/$dir_name/ dist/parks-reso-public
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 900
+          role-session-name: parks-reso-public-test-gh-action
+          role-skip-session-tagging: true
+
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
+        with:
+          ssm_parameter: '/parks-reso-public/s3-bucket'
+          env_variable_name: 'S3_BUCKET'
+
+      - name: Deploy to Test S3
+        env:
+          s3_bucket: '${{ env.S3_BUCKET }}-${{ env.TARGET_ENV }}'
+          dir_name: ${{ github.event.inputs.releaseTag }}
+        run: |
+          aws s3 sync dist/parks-reso-public s3://$s3_bucket/$dir_name/dayuse
+
   terragrunt:
     name: Run Terragrunt
+    needs: ['s3']
     runs-on: ubuntu-20.04
     environment: test
     strategy:
@@ -25,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-            ref: ${{ github.event.inputs.releaseTag }}
+          ref: ${{ github.event.inputs.releaseTag }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -39,38 +94,38 @@ jobs:
           role-skip-session-tagging: true
 
       # Public variables
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
-          ssm_parameter: "/parks-reso-public/s3-bucket"
-          env_variable_name: "S3_BUCKET"
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+          ssm_parameter: '/parks-reso-public/s3-bucket'
+          env_variable_name: 'S3_BUCKET'
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
-          ssm_parameter: "/parks-reso-public/origin-id"
-          env_variable_name: "ORIGIN_ID"
+          ssm_parameter: '/parks-reso-public/origin-id'
+          env_variable_name: 'ORIGIN_ID'
 
       # API variables
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
           ssm_parameter: /parks-reso-api/origin-domain
-          env_variable_name: "API_GATEWAY_ORIGIN_DOMAIN"
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+          env_variable_name: 'API_GATEWAY_ORIGIN_DOMAIN'
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
           ssm_parameter: /parks-reso-api/origin-id
-          env_variable_name: "API_GATEWAY_ORIGIN_ID"
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+          env_variable_name: 'API_GATEWAY_ORIGIN_ID'
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
           ssm_parameter: /parks-reso-api/gateway-path-pattern
-          env_variable_name: "API_GATEWAY_PATH_PATTERN"
+          env_variable_name: 'API_GATEWAY_PATH_PATTERN'
 
       # Shared variables
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
-          ssm_parameter: "/parks-reso-shared/s3-bucket-assets"
-          env_variable_name: "S3_BUCKET_ASSETS"
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
+          ssm_parameter: '/parks-reso-shared/s3-bucket-assets'
+          env_variable_name: 'S3_BUCKET_ASSETS'
+      - uses: 'marvinpinto/action-inject-ssm-secrets@v1.2.1'
         with:
-          ssm_parameter: "/parks-reso-shared/origin-id-assets"
-          env_variable_name: "ORIGIN_ID_ASSETS"
+          ssm_parameter: '/parks-reso-shared/origin-id-assets'
+          env_variable_name: 'ORIGIN_ID_ASSETS'
 
       - name: Setup Terrafrom
         uses: hashicorp/setup-terraform@v1
@@ -95,58 +150,3 @@ jobs:
           api_gateway_path_pattern: ${{ env.API_GATEWAY_PATH_PATTERN }}
           origin_id_assets: ${{ env.ORIGIN_ID_ASSETS }}
         run: terragrunt apply-all --terragrunt-non-interactive
-
-  s3:
-    name: Upload to S3
-    needs: terragrunt
-    runs-on: ubuntu-20.04
-    environment: test
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SANDBOX }}
-          role-duration-seconds: 900
-          role-session-name: parks-reso-public-sandbox-gh-action
-          role-skip-session-tagging: true
-
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
-        with:
-          ssm_parameter: "/parks-reso-sandbox/s3-bucket-public-artifacts"
-          env_variable_name: "S3_BUCKET_ARTIFACTS"
-
-      - name: Copy from s3 sandbox
-        env:
-          s3_bucket: "${{ env.S3_BUCKET_ARTIFACTS }}"
-          dir_name: ${{ github.sha }}
-        run: |
-          aws s3 sync s3://$s3_bucket/$dir_name/ dist/parks-reso-public
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
-          role-session-name: parks-reso-public-test-gh-action
-          role-skip-session-tagging: true
-
-      - uses: "marvinpinto/action-inject-ssm-secrets@v1.2.1"
-        with:
-          ssm_parameter: "/parks-reso-public/s3-bucket"
-          env_variable_name: "S3_BUCKET"
-
-      - name: Deploy to Test S3
-        env:
-          s3_bucket: "${{ env.S3_BUCKET }}-${{ env.TARGET_ENV }}"
-          dir_name: ${{ github.event.inputs.releaseTag }}
-        run: |
-          aws s3 sync dist/parks-reso-public s3://$s3_bucket/$dir_name/dayuse


### PR DESCRIPTION
### Jira Ticket:

BRS-219

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-219

### Description:

Updating the cloudfront distribution can take 2+ minutes (up to 25 or so), during which some edge locations will try to access the new content, even if it hasn't been uploaded to S3 yet.

Note this creates a potential problem if we change the S3 bucket name, since the bucket is managed by terragrunt which is now run after the upload. I haven't found a solution for that - it shouldn't be something that happens often though.

Also format actions files with prettier.
