### PR TITLE
NOBUG: disable AM slot if beyond AM time

### DIFF
--- a/src/app/registration/facility-select/facility-select.component.html
+++ b/src/app/registration/facility-select/facility-select.component.html
@@ -70,7 +70,7 @@
               Pass availability -
               <span [ngClass]="timeConfig.AM.text">{{ timeConfig.AM.text }}</span>
             </p>
-            <p class="card-text">7am&ndash;12pm (Depart by noon)</p>
+            <p class="card-text">{{to12hTimeString(defaultAMOpeningHour)}}&ndash;12pm (Depart by noon)</p>
           </div>
         </div>
       </label>

--- a/src/app/registration/facility-select/facility-select.component.ts
+++ b/src/app/registration/facility-select/facility-select.component.ts
@@ -154,6 +154,7 @@ export class FacilitySelectComponent implements OnInit {
     this.selectedDate = '';
     if (this.myForm.get('passType').value && this.myForm.get('passType').value.bookingTimes) {
       const facility = this.myForm.get('passType').value;
+      this.defaultAMOpeningHour = this.bookingOpeningHour;
       const times = this.myForm.get('passType').value.bookingTimes;
       if (times.AM) {
         this.timeConfig.AM.offered = true;

--- a/src/app/registration/facility-select/facility-select.component.ts
+++ b/src/app/registration/facility-select/facility-select.component.ts
@@ -19,7 +19,7 @@ export class FacilitySelectComponent implements OnInit {
   public closedFacilities = [];
   public passesAvailable = [];
   public selectedDate = '';
-  public expiredText = "This time slot has expired"
+  public expiredText = 'This time slot has expired';
 
   public timeConfig = {
     AM: {
@@ -107,7 +107,7 @@ export class FacilitySelectComponent implements OnInit {
     const bookingDate = this.getBookingDate();
     // check the current time in the America/Vancouver TZ (must do this step to acct for PST/PDT)
     const currentHour = localDate.toLocaleString('en-US', { hour: '2-digit', hour12: false, timeZone: 'America/Vancouver' });
-    localDate.setHours(0,0,0,0);
+    localDate.setHours(0, 0, 0, 0);
     if (localDate >= bookingDate && parseInt(currentHour, 10) >= this.defaultPMOpeningHour ){
       return true;
     }


### PR DESCRIPTION
### Jira Ticket:

NOBUG

### Description:

https://bcparksdigital.atlassian.net/browse/BRS-294 added API functionality to prevent AM passes from being created if the AM time slot had already transpired (trying to book an AM pass after 12pm on the same day). The API will now correctly deny users who try to do this - however, the AM slot still shows available on the public side and users will go through the whole workflow before they are told by the API their booking is not possible. This change disables the AM slot on the public front end if the current time is beyond the PM time slot opening time (12pm).
