### PR TITLE
BRS-296 show date after successful booking cancellation

### DIFF
--- a/src/app/pass-lookup/pass-lookup.component.ts
+++ b/src/app/pass-lookup/pass-lookup.component.ts
@@ -1,3 +1,4 @@
+import { formatDate } from '@angular/common';
 import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Pass } from '../models/pass';
@@ -24,6 +25,7 @@ export class PassLookupComponent implements OnInit {
   public backButtonText = 'Home';
 
   public validationData = '';
+  public cancelledPassData = null;
 
   public urlData = {
     passId: '',
@@ -96,10 +98,15 @@ export class PassLookupComponent implements OnInit {
   }
 
   passSuccessfullyCancelled(): AlertObject {
+    let passDetails = ``;
+    if (this.cancelledPassData?.date && this.cancelledPassData?.type) {
+      passDetails = `for ${ formatDate(this.cancelledPassData.date, 'mediumDate', 'en-CA')} - ${this.cancelledPassData.type} `;
+      console.log(passDetails);
+    }
     let alert = new AlertObject({
       type: 'info',
       title: 'Successful reservation cancel',
-      message: '<span>Your reservation has been successfully cancelled</span>',
+      message: `<span>Your reservation <strong>${passDetails}</strong>has been successfully cancelled</span>`,
       smallAlert: true
     });
     return alert;
@@ -144,6 +151,9 @@ export class PassLookupComponent implements OnInit {
       return;
     }
     if (res) {
+      if (res.pass) {
+        this.cancelledPassData = res.pass;
+      }
       this.changeState('cancelled');
       return;
     }

--- a/src/app/shared/components/alert/alert.component.html
+++ b/src/app/shared/components/alert/alert.component.html
@@ -17,7 +17,7 @@
     </div>
 </div>
 
-<div *ngIf="data?.smallAlert" class="p-3 my-2 text-center smallAlert " [ngClass]="getAlertClass(data?.type)"
+<div *ngIf="data?.smallAlert" class="p-3 my-2 text-center smallAlert" [ngClass]="getAlertClass(data?.type)"
     title='{{data?.title}}'>
     <div class="row justify-content-center d-flex align-items-center">
         <div class="col-lg-1 justify-content-center d-flex align-items-center">

--- a/src/app/shared/components/alert/alert.module.ts
+++ b/src/app/shared/components/alert/alert.module.ts
@@ -1,9 +1,10 @@
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { AlertComponent } from './alert.component';
 
 @NgModule({
   declarations: [AlertComponent],
-  imports: [],
+  imports: [CommonModule],
   exports: [AlertComponent]
 })
 export class AlertModule {}


### PR DESCRIPTION
### Jira Ticket:

BRS-296

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-296

### Description:

This change displays the date and time of day of a pass to the front end if it was successfully cancelled. Note: this change requires https://github.com/bcgov/parks-reso-api/pull/91 in order to work.

Recommend approving https://github.com/bcgov/parks-reso-api/pull/91 first and doing testing with `dev` API, as there are many gotchas with running cancellation workflows in the `local` env when GCNotify is involved.
