### PR TITLE
NOBUG: Store pass date as noon UTC instead of using the browser timezone

### DIFF
--- a/src/app/registration/registration.component.ts
+++ b/src/app/registration/registration.component.ts
@@ -140,7 +140,7 @@ export class RegistrationComponent implements OnInit {
     obj.facilityName = this.regData.passType.name;
     obj.numberOfGuests = this.regData.passCount;
     obj.email = this.regData.email;
-    obj.date = new Date(
+    obj.date = new Date(Date.UTC(
       this.regData.visitDate.year,
       this.regData.visitDate.month - 1,
       this.regData.visitDate.day,
@@ -148,7 +148,7 @@ export class RegistrationComponent implements OnInit {
       0,
       0,
       0
-    );
+    ));
     obj.type = this.regData.visitTime;
     obj.parkName = this.park.name;
     obj.facilityType = this.regData.passType.type;


### PR DESCRIPTION
I noticed the pass date  were being stored as 19:00 in DynamoDB e.g. `2022-05-26T19:00:00.000Z`
- This was happening because noon Vancouver time is 7PM UTC.  
- If somebody in Calgary booked a pass, it would be stored as 18:00
- If somebody booked a pass in the winter (standard time), it would be stored as 20:00

### Jira Ticket:

Related to BRS-309 and BRS-595

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-309
https://bcparksdigital.atlassian.net/browse/BRS-595

### Description:

Minor change to the Angular code to always store the pass as Noon UTC.  

