### PR TITLE
BRS-656: fixing datepicker to PST

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@digitalspace/bcparks-bootstrap-theme": "^1.0.6",
     "@ng-bootstrap/ng-bootstrap": "10.0.0",
     "guid-typescript": "^1.0.9",
+    "luxon": "^2.4.0",
     "material-icons": "^0.6.3",
     "ngx-pagination": "^5.1.0",
     "ngx-toastr": "^13.2.1",

--- a/src/app/registration/registration-details/registration-details.component.html
+++ b/src/app/registration/registration-details/registration-details.component.html
@@ -23,7 +23,7 @@
             Date
         </p>
         <h3>
-            {{ regData?.date | date : 'mediumDate' }}
+            {{ regData?.shortPassDate | date : 'mediumDate' }}
         </h3>
         <hr>
     </div>

--- a/src/app/registration/registration.component.ts
+++ b/src/app/registration/registration.component.ts
@@ -6,6 +6,7 @@ import { FacilityService } from '../services/facility.service';
 import { PassService } from '../services/pass.service';
 import { ToastService } from '../services/toast.service';
 import { Constants } from '../shared/utils/constants';
+import { DateTime } from 'luxon';
 
 @Component({
   selector: 'app-registration',
@@ -134,21 +135,28 @@ export class RegistrationComponent implements OnInit {
   }
 
   populatePassObj(obj) {
+    const visitDateTime = DateTime.fromObject(
+      {
+        year: this.regData.visitDate.year,
+        month: this.regData.visitDate.month,
+        day: this.regData.visitDate.day,
+        hour: 12,
+        minute: 0,
+        second: 0,
+        millisecond: 0
+      },
+      {
+        zone: 'America/Vancouver'
+      }
+    );
+    const visitUTCISODate = visitDateTime.toUTC().toISO();
     // Mandatory fields:
     obj.firstName = this.regData.firstName;
     obj.lastName = this.regData.lastName;
     obj.facilityName = this.regData.passType.name;
     obj.numberOfGuests = this.regData.passCount;
     obj.email = this.regData.email;
-    obj.date = new Date(
-      this.regData.visitDate.year,
-      this.regData.visitDate.month - 1,
-      this.regData.visitDate.day,
-      12,
-      0,
-      0,
-      0
-    );
+    obj.date = visitUTCISODate;
     obj.type = this.regData.visitTime;
     obj.parkName = this.park.name;
     obj.facilityType = this.regData.passType.type;

--- a/src/app/shared/components/date-picker/date-picker.component.ts
+++ b/src/app/shared/components/date-picker/date-picker.component.ts
@@ -45,10 +45,10 @@ export class DatePickerComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.minDate && changes.minDate.currentValue) {
-      this.minNgbDate = this.utils.convertJSDateToNGBDate(new Date(changes.minDate.currentValue));
+      this.minNgbDate = this.utils.convertJSDateToZonedNGBDate(new Date(changes.minDate.currentValue));
     }
     if (changes.maxDate && changes.maxDate.currentValue) {
-      this.maxNgbDate = this.utils.convertJSDateToNGBDate(new Date(changes.maxDate.currentValue));
+      this.maxNgbDate = this.utils.convertJSDateToZonedNGBDate(new Date(changes.maxDate.currentValue));
     }
 
     this.loading = false;

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { DateTime } from 'luxon';
 
 const encode = encodeURIComponent;
 window['encodeURIComponent'] = (component: string) => {
@@ -30,11 +31,24 @@ export class Utils {
 
   }
 
+  // converts JS Date (UTC) to time zone offset NGBDate (America/Vancouver if no time zone provided)
+  public convertJSDateToZonedNGBDate(jSDate: any, timeZone = 'America/Vancouver'): any {
+    if (!jSDate) {
+      return null;
+    }
+    const options = { zone: timeZone };
+    const dateTime = DateTime.fromJSDate(new Date(jSDate), options);
+    return {
+      year: dateTime.get('year'),
+      month: dateTime.get('month'),
+      day: dateTime.get('day'),
+    };
+  }
+
   public convertJSDateToNGBDate(jSDate: Date): any {
     if (!jSDate) {
       return null;
     }
-
     return {
       year: jSDate.getFullYear(),
       month: jSDate.getMonth() + 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3349,9 +3349,9 @@ ejs@^3.1.5:
     jake "^10.8.5"
 
 electron-to-chromium@^1.4.147:
-  version "1.4.147"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.147.tgz#1ecf318737b21ba1e5b53319eb1edf8143892270"
-  integrity sha512-czclPqxLMPqPMkahKcske4TaS5lcznsc26ByBlEFDU8grTBVK9C5W6K9I6oEEhm4Ai4jTihGnys90xY1yjXcRg==
+  version "1.4.148"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.148.tgz#437430e03c58ccd1d05701f66980afe54d2253ec"
+  integrity sha512-8MJk1bcQUAYkuvCyWZxaldiwoDG0E0AMzBGA6cv3WfuvJySiPgfidEPBFCRRH3cZm6SVZwo/oRlK1ehi1QNEIQ==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -5281,7 +5281,7 @@ luxon@^2.4.0:
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.4.0.tgz#9435806545bb32d4234dab766ab8a3d54847a765"
   integrity sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA==
 
-magic-string@0.25.7, magic-string@^0.25.0:
+magic-string@0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5276,7 +5276,12 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-magic-string@0.25.7:
+luxon@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.4.0.tgz#9435806545bb32d4234dab766ab8a3d54847a765"
+  integrity sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA==
+
+magic-string@0.25.7, magic-string@^0.25.0:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==


### PR DESCRIPTION
### Jira Ticket:

BRS-656

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-656

### Description:

This change ensures that the front-end datepicker always resides in the PST/PDT timezone 'America/Vancouver'. Previously, the dates shown were influenced by the browser's local timezone, sometimes resulting in the wrong days being displayed. This change leverages the datetime package `luxon` to handle timezone offsets. The front end now always shows dates as they would be at that instant in PST/PDT. Dates are passed to the back-end as UTC ISO time format for 12:00 noon PST/PDT on the selected booking date. 

Dates shown in other parts of the app have been formatted to display in PST/PDT where appropriate. 

This change will be accompanied in the future by changes to the API/back-end such that they will also handle dates properly; however, the public front end will work as intended without changes to the back end (so long as the code is hosted on servers set to UTC).
