### PR TITLE
BRS-656 initializing today in datepicker

### DIFF
--- a/src/app/registration/facility-select/facility-select.component.html
+++ b/src/app/registration/facility-select/facility-select.component.html
@@ -7,6 +7,7 @@
       [label]="'visitDate'"
       [control]="myForm.controls.visitDate"
       [isValidate]="true"
+      [today]="initDate"
       [minDate]="minDate"
       (formChangeEvent)="onVisitDateChange()"
       (clearEvent)="resetTimeConfig()"

--- a/src/app/registration/facility-select/facility-select.component.ts
+++ b/src/app/registration/facility-select/facility-select.component.ts
@@ -20,6 +20,7 @@ export class FacilitySelectComponent implements OnInit {
   public closedFacilities = [];
   public passesAvailable = [];
   public selectedDate = '';
+  public initDate = {};
   public expiredText = 'This time slot has expired';
 
   public timeConfig = {
@@ -67,8 +68,15 @@ export class FacilitySelectComponent implements OnInit {
       this.defaultDateLimit = this.configService.config['ADVANCE_BOOKING_LIMIT'];
       this.defaultAMOpeningHour = this.configService.config['ADVANCE_BOOKING_HOUR'];
     }
+    const today = this.getPSTDateTime();
+    this.initDate = {
+      year: today.get('year'),
+      month: today.get('month'),
+      day: today.get('day')
+    }
     this.initForm();
     this.checkPassType();
+    this.setState('facility');
     this.timeConfig.AM.disabled = this.isAMSlotExpired;
   }
 
@@ -443,6 +451,7 @@ export class FacilitySelectComponent implements OnInit {
       passType: ['', Validators.required],
       passCount: ['', Validators.required]
     });
+    this.myForm.controls['visitDate'].setValue(this.initDate);
   }
 
   submit(): void {

--- a/src/app/shared/components/date-picker/date-picker.component.html
+++ b/src/app/shared/components/date-picker/date-picker.component.html
@@ -29,7 +29,7 @@
   </button>
 </fieldset>
 
-<div class="invalid-feedback bg-danger"
+<div class="invalid-feedback"
   *ngIf="isValidate && !isValidDate(ngbDate)">
   Enter a valid date
 </div>

--- a/src/app/shared/components/date-picker/date-picker.component.ts
+++ b/src/app/shared/components/date-picker/date-picker.component.ts
@@ -29,6 +29,7 @@ export class DatePickerComponent implements OnInit, OnChanges, OnDestroy {
   @Input() reset: EventEmitter<any>;
   @Input() required = false;
   @Input() label = '';
+  @Input() today: NgbDateStruct = null;
 
   @Output() formChangeEvent = new EventEmitter<string>();
   @Output() clearEvent = new EventEmitter();
@@ -56,7 +57,7 @@ export class DatePickerComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.ngbDate = this.control.value || null;
+    this.ngbDate = this.today || null;
     if (this.reset) {
       this.reset.pipe(takeUntil(this.ngUnsubscribe)).subscribe(() => this.clearDate());
     }


### PR DESCRIPTION
### Jira Ticket:

BRS-656

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-656

### Description:

Setting browser timezone to U+14 caused the datepicker to indicate that 'today' was tomorrow, though no actual date was selected (datepicker with `null` date). There is no way to prevent datepicker from assuming today's date based on the local browser time, so now when selecting a pass, today's date (in PST) is prepopulated when the form is initialized. This way, there is never a `null` date in the datepicker.