### PR TITLE
BRS-800: DUP Public - Booking time - Custom text is displayed over de…

### DIFF
--- a/src/app/registration/facility-select/facility-select.component.html
+++ b/src/app/registration/facility-select/facility-select.component.html
@@ -42,7 +42,7 @@
     <div id="bookingTime" *ngIf="!timeConfig.AM.offered && !timeConfig.PM.offered && !timeConfig.DAY.offered">
       <p class="text-muted">Please select a pass type to see available passes for the selected date.</p>
     </div>
-    <div *ngIf="!isBookableDay && myForm.get('passType').value">
+    <div *ngIf="!isBookableDay && !!myForm.get('passType').value">
       <p [innerHTML]="notRequiredText"></p>
     </div>
     <div class="row row-cols-1 row cols-md-3 g-4" *ngIf="isBookableDay">

--- a/src/app/registration/facility-select/facility-select.component.ts
+++ b/src/app/registration/facility-select/facility-select.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { DatePickerComponent } from 'src/app/shared/components/date-picker/date-picker.component';
 import { ConfigService } from 'src/app/shared/services/config.service';
 import { DateTime } from 'luxon';
+import { Constants } from '../../shared/utils/constants';
 
 @Component({
   selector: 'app-facility-select',
@@ -22,7 +23,7 @@ export class FacilitySelectComponent implements OnInit {
   public selectedDate = '';
   public initDate = {};
   public expiredText = 'This time slot has expired';
-  public notRequiredText = `<p>You don't need a day-use pass for this date and pass type. Passes may be required on other days and at other parks.</p>`;
+  public notRequiredText = Constants.DEFAULT_NOT_REQUIRED_TEXT;
 
   public timeConfig = {
     AM: {
@@ -143,11 +144,13 @@ export class FacilitySelectComponent implements OnInit {
   }
 
   get isBookableDay(): boolean {
-    if (this.myForm.get('passType').value) {
+    if (!!this.myForm.get('passType').value) {
       const facility = this.myForm.get('passType').value;
       const bookingWeekday = this.getBookingDate().weekdayLong;
       if (facility.bookingDaysRichText) {
         this.notRequiredText = facility.bookingDaysRichText;
+      } else {
+        this.notRequiredText = Constants.DEFAULT_NOT_REQUIRED_TEXT;
       }
       if (facility.bookingDays[bookingWeekday]) {
         return true;

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -14,6 +14,8 @@ export class Constants {
     ]
   };
 
+  public static readonly DEFAULT_NOT_REQUIRED_TEXT = `<p>You don't need a day-use pass for this date and pass type. Passes may be required on other days and at other parks.</p>`;
+
   public static readonly mockPass1 = {
     _id: 100,
     _schemaName: 'Pass',
@@ -106,7 +108,6 @@ export class Constants {
     facilities: []
   };
 
-
   public static readonly mockParkList = [
     Constants.mockPark1,
     Constants.mockPark2,
@@ -126,6 +127,6 @@ export class Constants {
     SUCCESS: 0,
     WARNING: 1,
     INFO: 2,
-    ERROR: 3,
+    ERROR: 3
   };
 }


### PR DESCRIPTION
…fault text

### Jira Ticket:

BRS-800

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-800

### Description:

This fixes an issue where selecting a facility with a custom message first, resulted in a non-bookable day using the custom text. Essentially the fix is to reset to the default string if the newly selected facility has an empty string for the rich text.
