### PR TITLE
BRS-911: Updating S3 Assets distribution blacklist

### DIFF
--- a/terraform/src/cloudfront.tf
+++ b/terraform/src/cloudfront.tf
@@ -225,8 +225,8 @@ resource "aws_cloudfront_distribution" "s3_assets_distribution" {
 
   restrictions {
     geo_restriction {
-      restriction_type = "whitelist"
-      locations        = ["US", "CA", "GB", "DE"]
+      restriction_type = "blacklist"
+      locations        = ["BY", "CF", "CN", "CD", "IR", "IQ", "KP", "LB", "LY", "ML", "MM", "NI", "RU", "SO", "SS", "SD", "SY", "UA", "VE", "YE", "ZW"]
     }
   }
 


### PR DESCRIPTION
### Jira Ticket:

BRS-911

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-911

### Description:

Updating our S3 Asset Cloudfront distribution to have the same `blacklist` rules as our public front end distribution.
