### PR TITLE
BUGFIX: Opening hour set by selected facility now

### DIFF
--- a/src/app/registration/facility-select/facility-select.component.ts
+++ b/src/app/registration/facility-select/facility-select.component.ts
@@ -97,15 +97,13 @@ export class FacilitySelectComponent implements OnInit {
   }
 
   get bookingOpeningHour(): number {
-    // As a temporary work-around, date rules for each park are currently based on
-    // the first open facility at the park. See BRS-570 for details
-    const facility = this.facilities?.find(f => f.status.state === 'open');
+    const facility = this.myForm.get('passType').value;
     let bookingOpeningHour = this.defaultAMOpeningHour;
 
     if (facility && (facility.bookingOpeningHour || facility.bookingOpeningHour === 0)) {
       bookingOpeningHour = facility.bookingOpeningHour;
     }
-
+    
     return bookingOpeningHour;
   }
 


### PR DESCRIPTION
Issue came up in https://bcparksdigital.atlassian.net/browse/BRS-1149 see comments.
Issue first noted in https://bcparksdigital.atlassian.net/browse/BRS-570 see comments.

