### PR TITLE
BRS-262: Changed hyperlink text on Park details to align with new format

### DIFF
--- a/src/app/registration/park-details/park-details.component.html
+++ b/src/app/registration/park-details/park-details.component.html
@@ -5,7 +5,7 @@
 <p [innerHTML]="park?.description"></p>
 
 <p *ngIf="park?.bcParksLink">
-    For more information about {{park?.name}}, visit the BC Parks page <a href="{{park?.bcParksLink}}" target="_blank">here</a>.
+    For more information about {{park?.name}}, visit the <a href="{{park?.bcParksLink}}" target="_blank">BC Parks page</a>.
 </p>
 
 <img class="img-fluid rounded mb-4"


### PR DESCRIPTION
fixes #262 
### Jira Ticket:

BRS-262

### Jira Ticket URL:

https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=38951146

### Description:

Updated the hyperlink text to be "BC Parks page" instead of "here".
