### PR TITLE
BRS:280 - Update front end for end of daylight savings

### DIFF
--- a/src/app/registration/facility-select/facility-select.component.html
+++ b/src/app/registration/facility-select/facility-select.component.html
@@ -76,7 +76,7 @@
               Pass availability -
               <span [ngClass]="timeConfig.AM.text">{{ timeConfig.AM.text }}</span>
             </p>
-            <p class="card-text" id="arrive-departure-text-AM">{{to12hTimeString(defaultAMOpeningHour)}}&nbsp;&ndash;&nbsp;1pm (Depart by 1pm)</p>
+            <p class="card-text" id="arrive-departure-text-AM">{{to12hTimeString(defaultAMOpeningHour)}}&nbsp;&ndash;&nbsp;12pm (Depart by 12pm)</p>
           </div>
         </div>
       </label>
@@ -110,7 +110,7 @@
               Pass availability -
               <span [ngClass]="timeConfig.PM.text">{{ timeConfig.PM.text }}</span>
             </p>
-            <p class="card-text" id="arrive-departure-text-PM">Arrive after 1pm</p>
+            <p class="card-text" id="arrive-departure-text-PM">Arrive after 12pm</p>
           </div>
         </div>
       </label>

--- a/src/app/registration/facility-select/facility-select.component.spec.ts
+++ b/src/app/registration/facility-select/facility-select.component.spec.ts
@@ -361,7 +361,7 @@ describe('FacilitySelectComponent', () => {
 
       const textElement = fixture.debugElement.query(By.css("#arrive-departure-text-AM"));
 
-      expect(textElement.nativeElement.textContent).toContain('1pm (Depart by 1pm)');
+      expect(textElement.nativeElement.textContent).toContain('12pm (Depart by 12pm)');
       expect(component.to12hTimeString(component.defaultAMOpeningHour)).toBe(component.defaultAMOpeningHour.toString()+"am");
       expect(true).toBeTrue()
     })
@@ -371,7 +371,7 @@ describe('FacilitySelectComponent', () => {
       fixture.detectChanges()
 
       const textElement = fixture.debugElement.query(By.css("#arrive-departure-text-PM"));
-      expect(textElement.nativeElement.textContent).toContain('Arrive after 1pm');
+      expect(textElement.nativeElement.textContent).toContain('Arrive after 12pm');
     })
 
     it('should test DAY arrival text', () => {


### PR DESCRIPTION
### Jira Ticket:

BRS-280

### Jira Ticket URL:

[https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=42572823](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=42572823)

### Description:

Text change to change the reservation times to reflect noon instead of 1pm.

