### PR TITLE
Removing 'parkingpass.bcparks.ca' as a vanity url

### DIFF
--- a/terraform/prod/terragrunt.hcl
+++ b/terraform/prod/terragrunt.hcl
@@ -37,6 +37,6 @@ auth_user = "${local.auth_user}"
 auth_pass = "${local.auth_pass}"
 enable_vanity_domain = true
 vanity_domain_certs_arn = "${local.ssl_cert_arn}"
-vanity_domain = ["parkingpass.bcparks.ca", "reserve.bcparks.ca"]
+vanity_domain = ["reserve.bcparks.ca"]
 EOF
 }


### PR DESCRIPTION
### Ticket: 

NOBUG

### Description:

Due to the wildcard cert causing problems with `*bcparks.ca` domains, DUP's certificates were recently upgraded to be more specific. DUP CloudFront no longer contains a wildcard certificate for `*bcparks.ca`, rather, it has `reserve.bcparks.ca` for DUP public and `reserve-admin.bcparks.ca` for DUP admin. The added complexity of doing this in Go Daddy vs Route53 has forced us to remove the other vanity url for DUP public, `parkingpass.bcparks.ca`. 

Terraform had this removed url hardcoded in its build files and would bomb when the ACM Cert ARN that it pulled didnt support `parkingpass.bcparks.ca`. This ticket is to remove that hardcode. Another ticket will have to be created to investigate the feasibility of reintroducing this vanity url if necessary.
