### PR TITLE
BRS-341 FIX: Typo fixes for Success page

### DIFF
--- a/src/app/registration/success/success.component.html
+++ b/src/app/registration/success/success.component.html
@@ -67,7 +67,7 @@
       <div class="mt-5">
         <h4>Next steps</h4>
         <p>
-          You will receive your pass via email soon. If you do not receive an email please contact
+          You will receive your pass by email soon. If you do not receive an email, please contact
           <a href="mailto:parkinfo@gov.bc.ca ">parkinfo&#64;gov.bc.ca</a>
           for assistance.
         </p>


### PR DESCRIPTION
### Jira Ticket:

BRS-341

### Jira Ticket URL:

#341 

### Description:

Fix two typos in the "Next steps" section of the success page.
- Replacing "via" with "by"
- Missing comma 
