### PR TITLE
BRS-323: Fix print screen appearing before qr img loads in doc

### DIFF
--- a/src/app/registration/success/success.component.spec.ts
+++ b/src/app/registration/success/success.component.spec.ts
@@ -93,6 +93,7 @@ describe('SuccessComponent', () => {
     } as unknown as Window;
     let dummyElement = document.createElement('div');
     document.getElementById = jasmine.createSpy('HTML Element').and.returnValue(dummyElement);
+    const mockEvent = new Event('load');
     let spy = spyOn(window, 'open').and.returnValue(windowMock)
     let spy2 = spyOn(windowMock, 'focus');
     let spy3 = spyOn(windowMock, 'print');
@@ -101,6 +102,7 @@ describe('SuccessComponent', () => {
     component.print();
     await fixture.detectChanges();
     await fixture.isStable();
+    windowMock.onload(mockEvent);
     expect(spy).toHaveBeenCalled();
     expect(spy2).toHaveBeenCalled();
     expect(spy3).toHaveBeenCalled();

--- a/src/app/registration/success/success.component.ts
+++ b/src/app/registration/success/success.component.ts
@@ -30,8 +30,11 @@ export class SuccessComponent implements OnInit {
     }
     WindowPrt.document.write(printContent.innerHTML);
     WindowPrt.document.close();
-    WindowPrt.focus();
-    WindowPrt.print();
+
+    WindowPrt.onload = () => {
+      WindowPrt.focus();
+      WindowPrt.print();
+    }
   }
 
   navigate(): void {


### PR DESCRIPTION
### Jira Ticket:

BRS-323

### Jira Ticket URL:

#323

### Description:

Fix an issue where the `print()` method was firing before the new document window loaded the QR code content.
- Document waits to fire the `focus()` and `print()` methods until after document is fully loaded using `onload()`
- Fix the unit test to check for `print()` and `focus()` after the `onload()` event.
