### PR TITLE
PDR-368 fixing facilities showing more passes than available

### DIFF
--- a/src/app/registration/facility-select/facility-select.component.ts
+++ b/src/app/registration/facility-select/facility-select.component.ts
@@ -305,7 +305,7 @@ export class FacilitySelectComponent implements OnInit {
           facility.reservations[date][time].max
         ) {
           // if so, check the remaining space available.
-          numberAvailable = facility.reservations[date][time].max;
+          numberAvailable = Math.min(facility.reservations[date][time].max, facility.bookingTimes[time].max);
         } else {
           numberAvailable = 0;
         }


### PR DESCRIPTION
Relates to #368 

Merging this in now that the hold pass timer stuff is in. Logic shouldnt affect hold pass. 

https://github.com/bcgov/parks-reso-public/issues/368

This error only occurs in the front end and is just a misrepresentation of the actual number of passes available. It only happens when you look ahead at a future date that has no bookings for it yet - the front end assumes that the max number of trail passes one person can book (4) is available if no reservation object exists.

It will also only occur if the total number of base passes allotted to a trail facility is less than 4, which likely will never occur.

This error does not occur for the current date.

This has been fixed by adding a clause where the front end always shows the minimum of 3 possible pass availability values: the actual number of passes available, the maximum number of passes allotted to the facility, and the max number a user can book at once (hardcoded to 4).


