### PR TITLE
Fix #425 : DUP Spelling error in message 'New - text message reminders with cancellation links...'

### DIFF
--- a/src/app/registration/contact-form/contact-form.component.html
+++ b/src/app/registration/contact-form/contact-form.component.html
@@ -28,7 +28,7 @@
     </div>
     <div class="col-md-12 col-lg-6 right-col">
       <div class="container-md rounded py-3 details-container">
-        <p><i><b>NEW</b> - Text message reminders with cancellation links can now be recieved by including your mobile
+        <p><i><b>NEW</b> - Text message reminders with cancellation links can now be received by including your mobile
             phone number below.</i></p>
       </div>
       <br>


### PR DESCRIPTION
Hello,
Hope you're doing well.
As if was requested in issue #425, I have updated the spelling of _**"received"**_ correctly.
If at all there's anything else required from my end, then do let me know.
Sincere apologies for my mistakes if you find any.

Thanks and Regards,
Mohit Kambli