### PR TITLE
BRS-449: Reorder Parks on DUP homepage

### DIFF
--- a/src/app/parks-list/parks-list.component.ts
+++ b/src/app/parks-list/parks-list.component.ts
@@ -58,10 +58,10 @@ export class ParksListComponent implements OnInit, OnDestroy {
             let tempClosedList = [];
             let specialClosureList = [];
             res.forEach(park => {
-              if (park.status === 'closed') {
-                tempClosedList.push({ ...park, ...{ tabindex: tabIndex } });
-              } else if (park.specialClosure === true ) {
+              if (park.specialClosure === true ) {
                 specialClosureList.push({ ...park, ...{ tabindex: tabIndex } });
+              } else if (park.status === 'closed') {
+                tempClosedList.push({ ...park, ...{ tabindex: tabIndex } });
               } else {
                 tempList.push({ ...park, ...{ tabindex: tabIndex } });
               }


### PR DESCRIPTION
Ticket: [BRS-449](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=78781413)
Notes: 
* During QA it was discovered if a park was "Closed" and had a "Special Closure" it would be considered a closed park not a special closure. 
* Changed the order for which its closed/specialClosure is decided to match expected behavior.