### PR TITLE
BRS: 424 - Booking Passes prior to 7am

### DIFF
--- a/src/app/registration/facility-select/facility-select.component.html
+++ b/src/app/registration/facility-select/facility-select.component.html
@@ -48,13 +48,7 @@
     <div *ngIf="showAsUnbookable">
       <p [innerHTML]="notRequiredText"></p> 
     </div>
-    <div *ngIf="!validBookingTime">
-      <div class="alert alert-warning" role="alert">
-        <i class="fa-solid fa-circle-exclamation fa-med"></i>
-        It is currently not within the booking window. Please refresh your browser after {{formattedBookingTime}}.
-      </div>
-    </div>
-    <div class="row row-cols-1 row-cols-md-3 g-4" *ngIf="!showAsUnbookable && validBookingTime">
+    <div class="row row-cols-1 row-cols-md-3 g-4" *ngIf="!showAsUnbookable">
       <label class="col-lg-12 fw-normal fs-6" *ngIf="timeConfig.AM.offered">
         <div
           class="card h-100 card-primary card-input"

--- a/src/app/registration/facility-select/facility-select.component.html
+++ b/src/app/registration/facility-select/facility-select.component.html
@@ -204,7 +204,7 @@
     <span class="material-icons md-24">arrow_back</span>
     Back
   </button>
-  <button type="button" [disabled]="myForm.status === 'INVALID' || loading || !validBookingTime" class="btn btn-primary"
+  <button type="button" [disabled]="myForm.status === 'INVALID' || loading" class="btn btn-primary"
     data-bs-toggle="modal" data-bs-target="#turnstileModal" (click)="showTurnstile()">
     Next
   </button>

--- a/src/app/registration/facility-select/facility-select.component.spec.ts
+++ b/src/app/registration/facility-select/facility-select.component.spec.ts
@@ -43,7 +43,6 @@ describe('FacilitySelectComponent', () => {
       // initialize the component
       component.facilities = facilities;
       component.ngOnInit();
-      component.validBookingTime = true;
       fixture.detectChanges();
 
       // set the visit date

--- a/src/app/registration/facility-select/facility-select.component.spec.ts
+++ b/src/app/registration/facility-select/facility-select.component.spec.ts
@@ -9,6 +9,7 @@ import { RegistrationModule } from '../registration.module';
 import { FacilitySelectComponent } from './facility-select.component';
 import { ServiceWorkerModule, SwUpdate } from '@angular/service-worker';
 import { PassService } from 'src/app/services/pass.service';
+import { DateTime } from 'luxon';
 
 describe('FacilitySelectComponent', () => {
   let component: FacilitySelectComponent;
@@ -26,6 +27,10 @@ describe('FacilitySelectComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(FacilitySelectComponent);
     component = fixture.componentInstance;
+    component.systemTimePST = DateTime.fromObject(
+      { year: 2021, month: 11, day: 23, hour: 20, minute: 2, second: 0, millisecond: 0 },
+      { zone: 'America/Vancouver' } // Set to PST
+    );
     fixture.detectChanges();
   });
 

--- a/src/app/registration/facility-select/facility-select.component.ts
+++ b/src/app/registration/facility-select/facility-select.component.ts
@@ -121,10 +121,6 @@ export class FacilitySelectComponent implements OnInit {
     if (facility && (facility.bookingOpeningHour || facility.bookingOpeningHour === 0)) {
       bookingOpeningHour = facility.bookingOpeningHour;
     }
-    const dateTime = DateTime.fromObject(
-      { hour: this.defaultAMOpeningHour, minute: 0 },
-      { zone: 'America/Vancouver' } // PST zone
-    );
     return bookingOpeningHour;
   }
 

--- a/src/app/shared/components/important-booking-info/important-booking-info.component.html
+++ b/src/app/shared/components/important-booking-info/important-booking-info.component.html
@@ -10,7 +10,7 @@
       data-bs-parent="#importantBookingAccordion">
       <div class="accordion-body">
         <p>
-          Book passes starting at 7:00am, two days before your visit.
+          Book passes starting at 7:00am two days before your visit. Refresh your browser at 7:00am to see new passes available each day.
         </p>
         <ul>
           <li>


### PR DESCRIPTION
Ticket: [BRS424](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=70969356&issue=bcgov%7Cparks-reso-public%7C424)
Notes: 
- This PR is for changing work done in [PR461](https://github.com/bcgov/parks-reso-public/pull/461)
- Front end will store system time from api on page load
- Will then use that time when determining maximum number of days available for booking. 
- All passes will open at 7am two days prior
- Remove alerts from displaying with facility, instead show that information within the Important Booking Information