### PR TITLE
BRS-459: Change Water-Droplet Icon to Drinking-Glass

### DIFF
--- a/src/app/registration/success/facilityConfirmation/diamondHead/diamondHeadConfirmation.component.html
+++ b/src/app/registration/success/facilityConfirmation/diamondHead/diamondHeadConfirmation.component.html
@@ -45,7 +45,7 @@
 
         <div class="row mb-3 align-content-center">
           <div class="col-auto me-1">
-              <i class="text-primary fa-solid fa-droplet fa-xl"></i>
+              <i class="text-primary fa-regular fa-glass-water fa-xl"></i>
             </div>
             <div class="col">
               Pack enough water, or be prepared to treat fresh water. There are no signifigant water sources beyond the 5 km mark on the trail until you reach Elfin Lakes at 11 km. 

--- a/src/app/registration/success/facilityConfirmation/garibaldi/rubbleCreek/rubbleCreekConfirmation.component.html
+++ b/src/app/registration/success/facilityConfirmation/garibaldi/rubbleCreek/rubbleCreekConfirmation.component.html
@@ -66,7 +66,7 @@
 
           <div class="row mb-3 align-content-center">
             <div class="col-auto me-1">
-              <i class="text-primary fa-solid fa-droplet fa-xl"></i>
+              <i class="text-primary fa-regular fa-glass-water fa-xl"></i>
             </div>
             <div class="col">
             Pack sufficient watter or be prepared to treat fresh water. There are no significant water sources before the 7 km mark on the trail.


### PR DESCRIPTION
Ticket: [BRS-459](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=80444271&issue=bcgov%7Cparks-reso-public%7C459)
Notes: 
* Changed the font awesome "droplet" to "glass-water" as requested by BC Parks content team.
* Ticket has requested specified width and height which we have talked about previously as a team. It was decided to use XL sizes for our font awesome icons as they were close to what was requested, and will scale according to our font size.
* Droplet was being used in RubbleCreek and DiamondHead both have been updated. 