### PR TITLE
BRS-521: Update Afternoon Start time for daylight savings

### DIFF
--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -14,7 +14,7 @@ export class Constants {
     ]
   };
 
-  public static readonly DEFAULT_PM_OPENING_HOUR = 13;
+  public static readonly DEFAULT_PM_OPENING_HOUR = 12;
 
   public static readonly DEFAULT_NOT_REQUIRED_TEXT = `<p>You don't need a day-use pass for this date and pass type. Passes may be required on other days and at other parks.</p>`;
 


### PR DESCRIPTION
BRS-521: Update day use morning passes to expire at noon, and afternoon passes to start at noon. 

notes: Same as this previous [PR](https://github.com/bcgov/parks-reso-public/pull/473/files) and this [PR](https://github.com/bcgov/parks-reso-public/pull/287/files). Second example has been simplified to only need to update the constant back in April 2024.

Will update with api ticket link when completed. 