### PR TITLE
DUP-542: Grab the Park name with supplied Orcs from URL, display that instead

### DIFF
--- a/src/app/pass-lookup/pass-lookup-form/pass-lookup-form.component.html
+++ b/src/app/pass-lookup/pass-lookup-form/pass-lookup-form.component.html
@@ -31,7 +31,9 @@
         <div *ngIf="urlData?.park">
             <label for="park">Park:</label>
             <div class="input-group mb-3">
-                <input type="text" id="park" placeholder="Park" class="form-control" formControlName="park" required>
+                <input type="text" id="park" placeholder="Park" class="form-control" 
+                    [value]="parkName || urlData?.park" readonly disabled>
+                <input type="hidden" formControlName="park">
             </div>
         </div>
     </form>

--- a/src/app/pass-lookup/pass-lookup-form/pass-lookup-form.component.spec.ts
+++ b/src/app/pass-lookup/pass-lookup-form/pass-lookup-form.component.spec.ts
@@ -1,16 +1,25 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
+import { of } from 'rxjs';
 
 import { PassLookupFormComponent } from './pass-lookup-form.component';
+import { ParkService } from '../../services/park.service';
 
 describe('PassLookupFormComponent', () => {
   let component: PassLookupFormComponent;
   let fixture: ComponentFixture<PassLookupFormComponent>;
+  let mockParkService: jasmine.SpyObj<ParkService>;
 
   beforeEach(async () => {
+    mockParkService = jasmine.createSpyObj('ParkService', ['fetchData', 'getItemValue']);
+    mockParkService.getItemValue.and.returnValue(of(null));
+
     await TestBed.configureTestingModule({
       imports: [ ReactiveFormsModule ],
-      declarations: [ PassLookupFormComponent ]
+      declarations: [ PassLookupFormComponent ],
+      providers: [
+        { provide: ParkService, useValue: mockParkService }
+      ]
     })
     .compileComponents();
   });

--- a/src/app/pass-lookup/pass-lookup-form/pass-lookup-form.component.ts
+++ b/src/app/pass-lookup/pass-lookup-form/pass-lookup-form.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, OnInit, Output, Input } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import { ParkService } from '../../services/park.service';
 
 @Component({
     selector: 'app-pass-lookup-form',
@@ -11,6 +12,7 @@ export class PassLookupFormComponent implements OnInit {
   @Input() urlData: any;
   @Output() submitEvent = new EventEmitter<any>();
 
+  public parkName = '';
   public formData = {
     passId: '',
     email: '',
@@ -27,6 +29,8 @@ export class PassLookupFormComponent implements OnInit {
     type: new UntypedFormControl('', Validators.required)
   });
 
+  constructor(private parkService: ParkService) {}
+
   ngOnInit(): void {
     this.disableForm();
     if (this.urlData) {
@@ -42,10 +46,24 @@ export class PassLookupFormComponent implements OnInit {
     this.lookupForm.enable();
   }
 
-  populateForm(data): void {
+  async populateForm(data: any): Promise<void> {
     for (let key in data){
-      if (this.lookupForm.get(key)){
-        this.lookupForm.controls[key].setValue(data[key]);
+      const control = this.lookupForm.get(key);
+      if (control && data[key] !== undefined){
+        control.setValue(data[key]);
+      }
+    }
+    // Fetch and display park name if park ORCS is provided
+    if (data?.park) {
+      try {
+        await this.parkService.fetchData(data.park);
+        this.parkService.getItemValue().subscribe(parkData => {
+          if (parkData?.name) {
+            this.parkName = parkData.name;
+          }
+        });
+      } catch (e) {
+        console.error('Failed to fetch park details:', e);
       }
     }
   }
@@ -60,11 +78,11 @@ export class PassLookupFormComponent implements OnInit {
   }
 
   updateFormData(): void {
-    this.formData.passId = this.lookupForm.get('passId').value;
-    this.formData.email = this.lookupForm.get('email').value;
-    this.formData.park = this.lookupForm.get('park').value;
-    this.formData.date = this.lookupForm.get('date').value;
-    this.formData.type = this.lookupForm.get('type').value;
+    this.formData.passId = this.lookupForm.get('passId')?.value || '';
+    this.formData.email = this.lookupForm.get('email')?.value || '';
+    this.formData.park = this.lookupForm.get('park')?.value || '';
+    this.formData.date = this.lookupForm.get('date')?.value || '';
+    this.formData.type = this.lookupForm.get('type')?.value || '';
   }
 
 }


### PR DESCRIPTION
Ticket: [542](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=182822346&issue=bcgov%7Cparks-reso-public%7C542)

Updating the cancellation form to display the park name instead of the ORCS.  
Upon deployment will test this in DEV. Should not effect any cancellation logic but am unable to send cancellation emails on local. 