### PR TITLE
BRS-276: Radio button with tab

### DIFF
--- a/src/app/registration/facility-select/facility-select.component.scss
+++ b/src/app/registration/facility-select/facility-select.component.scss
@@ -8,9 +8,9 @@ label {
     box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.2), 0 2px 5px 0 rgba(0, 0, 0, 0.19);
 }
 
-input[type="radio"] {
-    visibility: hidden;
-}
+// input[type="radio"] {
+//     visibility: hidden;
+// }
 
 input[type="radio"]:after {
     width: 1rem;


### PR DESCRIPTION
Ticket: [276](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=42110330&issue=bcgov%7Cparks-reso-public%7C276)

Notes: The custom radio buttons previously implemented are causing the accessibility issues. Removing the hidden on page load will allow them to be accessed with tab. 

The css to make them Parks themed may also prove to be an issue. We have increased their size which partially covers highlight from "Tab focus". 