### PR TITLE
fix(facility-select): shift AM/PM pass boundary from 12pm to 1pm

### DIFF
--- a/src/app/registration/facility-select/facility-select.component.spec.ts
+++ b/src/app/registration/facility-select/facility-select.component.spec.ts
@@ -366,11 +366,11 @@ describe('FacilitySelectComponent', () => {
 
     it('should test PM arrival text', () => {
       component.timeConfig.PM.offered = true;
-      component.defaultPMOpeningHour = 12;
+      component.defaultPMOpeningHour = 13;
       fixture.detectChanges();
 
       const textElement = fixture.debugElement.query(By.css("#arrive-departure-text-PM"));
-      expect(textElement.nativeElement.textContent).toContain('Arrive after 12pm');
+      expect(textElement.nativeElement.textContent).toContain('Arrive after 1pm');
     });
 
     it('should test DAY arrival text', () => {

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -14,7 +14,7 @@ export class Constants {
     ]
   };
 
-  public static readonly DEFAULT_PM_OPENING_HOUR = 12;
+  public static readonly DEFAULT_PM_OPENING_HOUR = 13;
 
   public static readonly DEFAULT_NOT_REQUIRED_TEXT = `<p>You don't need a day-use pass for this date and pass type. Passes may be required on other days and at other parks.</p>`;
 


### PR DESCRIPTION
- `DEFAULT_PM_OPENING_HOUR` 12 → 13 — drives the AM-pass row (`7am – 1pm`, `Depart by 1pm`), the PM-pass card (`Arrive after 1pm`), and the same-day PM-availability check
- Update PM-arrival-text spec to assert the new default

Ref #550