### PR TITLE
fix: exclude /api paths from service worker navigation URL handling

### DIFF
--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -1,6 +1,11 @@
 {
   "$schema": "./node_modules/@angular/service-worker/config/schema.json",
   "index": "/index.html",
+  "navigationUrls": [
+    "/**",
+    "!/**/*.*",
+    "!/api/**"
+  ],
   "assetGroups": [
     {
       "name": "app",

--- a/src/app/registration/facility-select/facility-select.component.spec.ts
+++ b/src/app/registration/facility-select/facility-select.component.spec.ts
@@ -366,11 +366,11 @@ describe('FacilitySelectComponent', () => {
 
     it('should test PM arrival text', () => {
       component.timeConfig.PM.offered = true;
-      component.defaultPMOpeningHour = 12;
+      component.defaultPMOpeningHour = 13;
       fixture.detectChanges();
 
       const textElement = fixture.debugElement.query(By.css("#arrive-departure-text-PM"));
-      expect(textElement.nativeElement.textContent).toContain('Arrive after 12pm');
+      expect(textElement.nativeElement.textContent).toContain('Arrive after 1pm');
     });
 
     it('should test DAY arrival text', () => {

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -14,7 +14,7 @@ export class Constants {
     ]
   };
 
-  public static readonly DEFAULT_PM_OPENING_HOUR = 12;
+  public static readonly DEFAULT_PM_OPENING_HOUR = 13;
 
   public static readonly DEFAULT_NOT_REQUIRED_TEXT = `<p>You don't need a day-use pass for this date and pass type. Passes may be required on other days and at other parks.</p>`;
 


### PR DESCRIPTION
Adds `navigationUrls` to `ngsw-config.json` to exclude `/api/**` from Angular's service worker navigation URL matching. Prevents the SW from treating API requests as Angular routes and caching HTML error responses for those paths. Deploying this also forces existing service workers to update and clear stale caches via the new `ngsw.json` hash.