### PR TITLE
fix(pass-lookup): recover cancel params when email HTML-encodes ampersands

### DIFF
--- a/src/app/pass-lookup/pass-lookup.component.ts
+++ b/src/app/pass-lookup/pass-lookup.component.ts
@@ -61,8 +61,13 @@ export class PassLookupComponent implements OnInit {
   checkUrlHeaders() {
     this.route.queryParams.subscribe(params => {
       for (let paramKey in params) {
-        if (this.urlData.hasOwnProperty(paramKey)) {
-          this.urlData[paramKey] = params[paramKey];
+        // Some email clients HTML-encode the ampersands in the cancellation
+        // link (& -> &amp;), so Angular parses keys as "amp;email", "amp;park",
+        // etc. and drops everything after the first param. Strip the stray
+        // "amp;" prefix so the remaining params are still recovered.
+        const normalizedKey = paramKey.replace(/^amp;/, '');
+        if (this.urlData.hasOwnProperty(normalizedKey)) {
+          this.urlData[normalizedKey] = params[paramKey];
         }
       }
     });


### PR DESCRIPTION
Cancelling via the confirmation-email link fails with "You must provide a pass email" (TEST, reg #125901285) when the client HTML-encodes the link's ampersands (`&`→`&amp;`). Angular then parses keys as `amp;email`/`amp;park`, dropping every param after `passId`.

Fix: strip a stray leading `amp;` from each query-param key in `checkUrlHeaders()` so email/park/date/type/code are recovered. No change for correctly-encoded links.