### PR TITLE
fix(config): fall back to serving origin when /api/config fetch fails

### DIFF
--- a/src/app/shared/services/config.service.ts
+++ b/src/app/shared/services/config.service.ts
@@ -30,8 +30,16 @@ export class ConfigService {
         // This will not work for local because it will try and get localhost:4200/api instead of 3000/api...
         this.configuration = await this.httpClient.get(`/api/config`).toPromise();
       } catch (e) {
-        // If all else fails, we'll just use the variables found in env.js
-        console.error('Error getting local configuration:', e);
+        // Config fetch failed: fall back to the serving origin, not the env.js localhost default.
+        console.error('Error getting configuration, falling back to serving origin:', e);
+        const host = window.location.hostname;
+        if (host !== 'localhost' && host !== '127.0.0.1') {
+          this.configuration = {
+            ...this.configuration,
+            API_LOCATION: window.location.origin,
+            ENVIRONMENT: 'prod'
+          };
+        }
       }
     }
 


### PR DESCRIPTION
When the runtime `/api/config` fetch fails, `ConfigService.init()` kept the `env.js` local-dev placeholders (`API_LOCATION=http://localhost:3000`, `ENVIRONMENT=local`). Subsequent API calls then hit localhost, so the page fails to load ("Error getting facilities") and shows a "local environment" banner.

Fix: on config-fetch failure, fall back to `window.location.origin` (same-origin `/api`) and `ENVIRONMENT=prod`. Local dev (served from localhost) is unaffected.