### PR TITLE
fix(registration): persist selected country on booked passes (#568)

### DIFF
--- a/src/app/models/pass.ts
+++ b/src/app/models/pass.ts
@@ -40,6 +40,7 @@ export class PostPass {
     email: string;
     firstName: string;
     lastName: string;
+    country: string;
 
     type: string; // AM, PM, DAY
     numberOfGuests: number;
@@ -59,6 +60,7 @@ export class PostPass {
         this.email = obj && obj.email || null;
         this.firstName = obj && obj.firstName || null;
         this.lastName = obj && obj.lastName || null;
+        this.country = obj && obj.country || null;
 
         this.type = obj && obj.type || null;
         this.numberOfGuests = obj && obj.numberOfGuests || null;

--- a/src/app/registration/registration.component.ts
+++ b/src/app/registration/registration.component.ts
@@ -175,6 +175,7 @@ export class RegistrationComponent implements OnInit {
     obj.parkOrcs = this.park.sk;
     obj.firstName = this.regData.firstName;
     obj.lastName = this.regData.lastName;
+    obj.country = this.regData.country;
     obj.facilityName = this.regData.passType.name;
     obj.numberOfGuests = this.regData.passCount;
     obj.email = this.regData.email;

--- a/src/app/services/pass.service.spec.ts
+++ b/src/app/services/pass.service.spec.ts
@@ -40,6 +40,30 @@ describe('PassService', () => {
 
             expect(apiService.post).toHaveBeenCalledWith('pass', jasmine.any(Object));
         });
+
+        it('should retain the country field on the posted pass', async () => {
+            const obj = {
+                parkOrcs: '1234',
+                numberOfGuests: 2,
+                lastName: 'joe',
+                facilityName: 'Facility A',
+                email: 'fresh@gmail.com',
+                firstName: 'fresh',
+                country: 'Canada',
+                date: new Date('2021-06-10T16:18:46.758Z'),
+                type: 'AM',
+                parkName: 'Rathtrevor',
+                phoneNumber: 1234567890,
+                facilityType: 'Trail',
+                token: 'testtoken',
+                commit: true,
+            };
+
+            await passService.createPass(obj, 'parkSk', 'facilitySk');
+
+            const postedPass = (apiService.post as jasmine.Spy).calls.mostRecent().args[1];
+            expect(postedPass.country).toBe('Canada');
+        });
     });
 
     describe('getPassToCancel', () => {


### PR DESCRIPTION
### Ticket:
#568

### Description:
QA send-back: the Country dropdown validated and submitted, but `country` never appeared on the pass record in DynamoDB.

The value was being dropped twice on the way to the wire:

- `populatePassObj()` copies fields onto the POST object one at a time and had no `obj.country`
- `createPass()` re-wraps via `new PostPass(obj)`, whose constructor only assigns declared fields — so `country` was stripped again

Both are fixed here. No API change was needed: `convertPassToReserved()` already accepts `country` and writes it conditionally, but the guard never fired because the field never arrived.

Also adds a service test asserting `country` survives to the request body — the existing test only asserted `jasmine.any(Object)`, which is why this shipped unnoticed.

Ref #568