### PR TITLE
chore(ci): update Node from 18.x to 22.x (#570)

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     defaults:
       run:
         working-directory: "./"

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     defaults:
       run:
         working-directory: "./"

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     defaults:
       run:
         working-directory: "./"

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,7 +27,7 @@ jobs:
     needs: install
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
     needs: install
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### Ticket:
#570

### Description:

Node 18 reached end-of-life in April 2025. This bumps the matrix from `18.x` to `22.x` in all four workflows — `on-pr`, `deploy-dev`, `deploy-test` and `deploy-prod`.

Node was pinned only in those workflows; there is no `.nvmrc`, `engines` or `volta` entry to keep in sync.

Verified locally on Node v22.22.2 against this codebase: 62/62 tests pass, lint clean, production build succeeds.

This also unblocks #562 (Angular 21), whose `Install (18.x)` job fails because Angular 21 requires Node 20+.

> [!IMPORTANT]
> **This PR cannot merge until branch protection is updated, and it will block other PRs when it does.**
>
> `main` requires status checks by literal name — currently `Lint (18.x)` and `Test (18.x)`. The matrix value is part of the check name, so this PR produces `Lint (22.x)` and `Test (22.x)` instead; the required contexts never report and the PR waits indefinitely.
>
> The required contexts must be changed to `Lint (22.x)` and `Test (22.x)` at the same time. Note that once changed, any **other** open PR still built on `18.x` will be blocked until it rebases onto this change.

Ref #570