### PR TITLE
fix(registration): label the country field "Country of residence" (#568)

### DIFF
--- a/src/app/registration/contact-form/contact-form.component.html
+++ b/src/app/registration/contact-form/contact-form.component.html
@@ -52,7 +52,7 @@
         </div>
         <div class="form-group">
           <label class="mb-2" for="country">
-            Country
+            Country of residence
            <span class="asteriks">&nbsp;*</span>
           </label>
           <select


### PR DESCRIPTION
### Ticket:
#568

### Description:

Renames the registration form's country field label from `Country` to `Country of residence` for clarity. Label text only — the control, validator and submitted value are unchanged.

Ref #568