### PR TITLE
test(timer): freeze the clock in the time-remaining spec

### DIFF
--- a/src/app/registration/timer/timer.component.spec.ts
+++ b/src/app/registration/timer/timer.component.spec.ts
@@ -26,11 +26,20 @@ describe('TimerComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  // ngOnInit calls DateTime.now() again rather than reusing the instant the
+  // expiry was built from, so any elapsed time between the two reads truncates
+  // 4m59.99s down to "4:59". Freezing the clock keeps both reads identical.
   it('should set the time remaining based on the expiry input', () => {
-    const expiry = DateTime.now().plus({ minutes: 5 });
-    component.expiry = expiry;
-    component.ngOnInit();
-    expect(component.timeRemaining).toBe('5:00');
+    jasmine.clock().install();
+    try {
+      jasmine.clock().mockDate(new Date(2026, 0, 1, 12, 0, 0));
+      component.expiry = DateTime.now().plus({ minutes: 5 });
+      component.ngOnInit();
+
+      expect(component.timeRemaining).toBe('5:00');
+    } finally {
+      jasmine.clock().uninstall();
+    }
   });
 
   it('should emit timerExpire event when timer expires', () => {


### PR DESCRIPTION
### Description:

`TimerComponent` failed intermittently in CI with `Expected '4:59' to be '5:00'` — it broke #577, a CODEOWNERS-only change, and passed on rerun.

The test builds `expiry` from `DateTime.now()`, then `ngOnInit()` calls `DateTime.now()` **again**. Any elapsed time between the two reads makes the duration 4m59.99s, which `toFormat('m:ss')` truncates to `4:59`. A real race, just one that usually wins.

Fix freezes the clock so both reads return the same instant.

Verified both directions: with the clock frozen the test passes even with 80ms of real time burned mid-test; with the clock removed and the same delay it fails with exactly the CI error.

Not fixing the component — re-reading the clock in `ngOnInit` is a design smell (see its own `TODO` about taking an end time from the API), but that's a behaviour change and out of scope here.