### PR TITLE
chore(ci): update Node from 18 to 22 (#570)

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     defaults:
       run:
         working-directory: "./"

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     defaults:
       run:
         working-directory: "./"

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     defaults:
       run:
         working-directory: "./"

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -2,13 +2,13 @@ name: PR Checks
 
 on: [pull_request]
 
+env:
+  NODE_VERSION: 22.x
+
 jobs:
   install:
     name: Install
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: "yarn"
       - run: yarn install --silent --frozen-lockfile
 
@@ -25,9 +25,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     needs: install
-    strategy:
-      matrix:
-        node-version: [18.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -36,7 +33,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: "yarn"
       - run: yarn install --silent --frozen-lockfile
 
@@ -46,9 +43,6 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     needs: install
-    strategy:
-      matrix:
-        node-version: [18.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -57,7 +51,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: "yarn"
       - run: yarn install --silent --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@angular/cli": "^19.2.1",
     "@angular/compiler-cli": "^19.2.1",
     "@types/jasmine": "^4.3.1",
-    "@types/node": "^18.16.2",
+    "@types/node": "^22",
     "@typescript-eslint/eslint-plugin": "7.11.0",
     "@typescript-eslint/parser": "7.11.0",
     "@typescript-eslint/types": "^8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2824,12 +2824,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^18.16.2":
-  version "18.19.31"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.31.tgz#b7d4a00f7cb826b60a543cebdbda5d189aaecdcd"
-  integrity sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==
+"@types/node@^22":
+  version "22.20.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.20.1.tgz#84e7cdf63cdaa20c134aa317ccc901aa21e16f0e"
+  integrity sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==
   dependencies:
-    undici-types "~5.26.4"
+    undici-types "~6.21.0"
 
 "@types/qs@*":
   version "6.9.15"
@@ -8061,6 +8061,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Ticket: #570

### Description

Moves DUP Public off Node 18 (EOL) onto Node 22, bringing it in line with `parks-reso-admin` and `parks-reso-api`, which already run 22.x. This is the prerequisite step agreed in BR — Node first, Angular upgrade separately.

- `deploy-dev` / `deploy-test` / `deploy-prod`: `node-version` 18.x → 22.x
- `on-pr`: hoisted the duplicated per-job matrix into a single `env.NODE_VERSION`, matching the pattern already used in `parks-reso-admin`
- `@types/node` bumped ^18.16.2 → ^22 so the types match the runtime

Node 22.x satisfies Angular 19 (`^18.19.1 || ^20.11.1 || ^22.0.0`) and clears the ≥22.22.0 floor Angular 21 will require, so the follow-up Angular ticket will not need another Node bump.

Verified locally on Node v22.23.1: `yarn install --frozen-lockfile`, `yarn lint`, `yarn build`, and `yarn test-ci` (62/62 passing) are all clean.

> Note: `main` branch protection required `Lint (18.x)` / `Test (18.x)`. Since dropping the matrix renames those checks, the required contexts have been updated to `Lint` / `Test` to match.

Ref #570